### PR TITLE
Fix issue where delete would error due to wrong entity name.

### DIFF
--- a/features/nav_menu.feature
+++ b/features/nav_menu.feature
@@ -24,7 +24,7 @@ Feature: Nav menus fixtures
       1
       """
 
-  Scenario: Delete terms
+  Scenario: Delete nav menus
     Given a WP install
     And a fixtures.yml file:
     """
@@ -37,8 +37,8 @@ Feature: Nav menus fixtures
     """
 
     When I run `wp fixtures load`
-    When I run `wp fixtures delete term --yes`
+    When I run `wp fixtures delete navMenu --yes`
     Then STDOUT should contain:
       """
-      1 term have been successfully deleted
+      1 navmenu have been successfully deleted
       """

--- a/features/nav_menu_item.feature
+++ b/features/nav_menu_item.feature
@@ -62,3 +62,43 @@ Feature: Nav menu item fixtures
       """
       post_type
       """
+
+  Scenario: Delete nav menu items
+    Given a WP install
+    And a fixtures.yml file:
+    """
+    Hellonico\Fixtures\Entity\Post:
+      post{1..4}:
+        post_title: <sentence()>
+      page:
+        post_title: <sentence()>
+    Hellonico\Fixtures\Entity\Term:
+      category{1..5}:
+        name (unique): <words(3, true)>
+    Hellonico\Fixtures\Entity\NavMenu:
+      header:
+        name: header
+        locations:
+          - header
+    Hellonico\Fixtures\Entity\NavMenuItem:
+      custom_menu:
+        menu_item_url: <url()>
+        menu_item_title: <words(4, true)>
+        menu_id: '@header->term_id'
+      categories{1..2}:
+        menu_item_object: '@category*'
+        menu_id: '@header->term_id'
+      posts{1..2}:
+        menu_item_object: '@post*'
+        menu_id: '@header->term_id'
+      page:
+        menu_item_object: '@page*'
+        menu_id: '@header->term_id'
+    """
+
+    When I run `wp fixtures load`
+    When I run `wp fixtures delete navMenuItem --yes`
+    Then STDOUT should contain:
+      """
+      6 navmenuitems have been successfully deleted
+      """

--- a/src/Command.php
+++ b/src/Command.php
@@ -113,7 +113,7 @@ class Command extends WP_CLI_Command
      */
     public function delete($args = [], array $assoc_args = [])
     {
-        $valid_types = ['post', 'attachment', 'nav_menu_item', 'term', 'nav_menu', 'comment', 'user'];
+        $valid_types = ['post', 'attachment', 'navMenuItem', 'term', 'navMenu', 'comment', 'user'];
 
         // Delete only a fixture type
         if (isset($args[0]) && !empty($args[0])) {

--- a/src/Entity/NavMenu.php
+++ b/src/Entity/NavMenu.php
@@ -20,4 +20,39 @@ class NavMenu extends Term
 
         return true;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function delete()
+    {
+        $query = new WP_Term_Query([
+            'taxonomy'   => 'nav_menu',
+            'fields'     => 'ids',
+            'hide_empty' => false,
+            'meta_query' => [
+                [
+                    'key'   => '_fake',
+                    'value' => true,
+                ],
+            ],
+        ]);
+
+        if (empty($query->terms)) {
+            WP_CLI::line(WP_CLI::colorize('%BInfo:%n No fake navmenus to delete'));
+
+            return false;
+        }
+
+        foreach ($query->terms as $id) {
+            $term = get_term($id);
+            if (!isset($term->taxonomy)) {
+                continue;
+            }
+            wp_delete_term($id, $term->taxonomy);
+        }
+        $count = count($query->terms);
+
+        WP_CLI::success(sprintf('%s navmenu%s have been successfully deleted', $count, $count > 1 ? 's' : ''));
+    }
 }

--- a/src/Entity/NavMenuItem.php
+++ b/src/Entity/NavMenuItem.php
@@ -98,4 +98,36 @@ class NavMenuItem extends Post
 
         return $data;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function delete()
+    {
+        $query = new WP_Query([
+            'fields'     => 'ids',
+            'meta_query' => [
+                [
+                    'key'   => '_fake',
+                    'value' => true,
+                ],
+            ],
+            'post_status'    => 'any',
+            'post_type'      => 'nav_menu_item',
+            'posts_per_page' => -1,
+        ]);
+
+        if (empty($query->posts)) {
+            WP_CLI::line(WP_CLI::colorize('%BInfo:%n No fake navmenuitems to delete'));
+
+            return false;
+        }
+
+        foreach ($query->posts as $id) {
+            wp_delete_post($id, true);
+        }
+        $count = count($query->posts);
+
+        WP_CLI::success(sprintf('%s navmenuitem%s have been successfully deleted', $count, $count > 1 ? 's' : ''));
+    }
 }

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -167,11 +167,10 @@ class Post extends Entity
             return false;
         }
 
-        // Remove attachment from types to delete
-        $attachment_index = array_search('attachment', $types);
-        if (false !== $attachment_index) {
-            unset($types[$attachment_index]);
-        }
+        // Filter out posts that have their own delete handlers.
+        $types = array_filter( $types, function($type) {
+            return !in_array($type, ['attachment', 'nan_menu_item']);
+        });
 
         $query = new WP_Query([
             'fields'     => 'ids',

--- a/src/Entity/Term.php
+++ b/src/Entity/Term.php
@@ -139,6 +139,10 @@ class Term extends Entity
             if (!isset($term->taxonomy)) {
                 continue;
             }
+            // Nav Menu's are handled within NavMenu.
+            if ($term->taxonomy === 'nav_menu') {
+                continue;
+            }
             wp_delete_term($id, $term->taxonomy);
         }
         $count = count($query->terms);


### PR DESCRIPTION
`PHP Fatal error:  Uncaught Error: Class
'Hellonico\Fixtures\Entity\Nav_menu_item' not found`

This corrects that by fixing the naming within the valid types array in
the delete command, but also adds delete commands to NavMenu and
NavMenuItem. It adds tests as well.