### PR TITLE
Add failing test for bug with parent terms.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
   },
   "require-dev": {
     "wp-cli/wp-cli-tests": "^3.0.9",
-    "wp-cli/entity-command": "^2.0"
+    "wp-cli/entity-command": "^2.0",
+    "wp-cli/db-command": "^2.0"
   },
   "config": {
     "process-timeout": 1800

--- a/examples/fixtures.yml
+++ b/examples/fixtures.yml
@@ -48,6 +48,7 @@ Hellonico\Fixtures\Entity\Term:
     parent: '50%? <termId(childless=1)>' # 50% of created categories will have a top level parent category
     taxonomy: 'category' # could be skipped, default to 'category'
   tag{1..40}:
+    __construct: ['post_tag'] # This is required to ensure the dynamic parent field above doesn't use tags as possible parents
     name (unique): <words(2, true)> # '(unique)' is required
     description: <sentence()>
     taxonomy: post_tag

--- a/features/term.feature
+++ b/features/term.feature
@@ -10,6 +10,7 @@ Feature: Term fixtures
         description: <sentence()>
         parent: '50%? <termId(childless=1)>'
       tag{1..5}:
+        __construct: ['post_tag']
         name (unique): <words(3, true)>
         description: <sentence()>
         taxonomy: post_tag

--- a/features/term.feature
+++ b/features/term.feature
@@ -39,6 +39,13 @@ Feature: Term fixtures
       5
       """
 
+    When I run `wp db query "SELECT COUNT(1) AS parent_tags FROM wp_term_taxonomy WHERE term_id IN ( SELECT parent FROM wp_term_taxonomy WHERE parent != 0 ) AND taxonomy = 'post_tag'"`
+    Then STDOUT should be:
+      """
+      parent_tags
+      0
+      """
+
   Scenario: Delete terms
     Given a WP install
     And a fixtures.yml file:

--- a/src/Entity/Term.php
+++ b/src/Entity/Term.php
@@ -16,6 +16,21 @@ class Term extends Entity
     public $acf;
 
     /**
+     * Constructor.
+     *
+     * @param int $id
+     * @param string $taxonomy
+     */
+    public function __construct($taxonomy = null)
+    {
+        if ($taxonomy === null) {
+            $taxonomy = $this->taxonomy;
+        }
+        $this->taxonomy = $taxonomy;
+        parent::__construct(false);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function create()


### PR DESCRIPTION
Only category terms can be hierarchical so you should only be able to
attach a parent to a term from the category taxonomy.

What happens in the scenario from the test is that each of the terms is created as a category then
during the perist the relevant ones are updated to be tags. However, the
parent has already been set as part of the create (due to `termId` being
called by the generator during creation).

I'm not entirely sure of the best way to fix this, but hopefully this
helps in showing the issue so a fix can be made.

How this affects things for the end user is if a parent is set on a
category and points to a tag you get lots `NOTICE: PHP message: PHP
Notice:  Trying to get property 'slug' of non-object in
/var/www/html/wp/wp-includes/taxonomy.php on line 4434` in the logs.

UPDATE: 2nd commit contains a possible fix.