### PR TITLE
PHP 8 fix for Picsum imageUrl method signature due to change to parent method in Faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/nlemoine/wp-cli-fixtures",
   "require": {
     "php": "^7.3 || ^8.0",
-    "fakerphp/faker": "^1.13",
+    "fakerphp/faker": "^1.20",
     "nelmio/alice": "^3.8",
     "wp-cli/wp-cli": "^2.4"
   },

--- a/src/Provider/Picsum.php
+++ b/src/Provider/Picsum.php
@@ -22,7 +22,8 @@ class Picsum extends Image
         $filters = [],
         $format = 'jpg',
         $unused = false,
-        $unused_ = false
+        $unused_ = false,
+        $unused3 = false,
     ) {
         $format = strtolower($format);
         $url    = sprintf(

--- a/src/Provider/Picsum.php
+++ b/src/Provider/Picsum.php
@@ -23,7 +23,7 @@ class Picsum extends Image
         $format = 'jpg',
         $unused = false,
         $unused_ = false,
-        $unused3 = false,
+        $unused3 = false
     ) {
         $format = strtolower($format);
         $url    = sprintf(

--- a/src/Provider/Picsum.php
+++ b/src/Provider/Picsum.php
@@ -83,6 +83,7 @@ class Picsum extends Image
             $ch = curl_init($url);
             curl_setopt($ch, CURLOPT_FILE, $fp);
             curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true); // Required for picsum to follow redirect.
+            curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (X11; Linux x86_64; rv:104.0) Gecko/20100101 Firefox/104.0'); // required as otherwise 403 error from picsum
             $success = curl_exec($ch) && curl_getinfo($ch, CURLINFO_HTTP_CODE) === 200;
             fclose($fp);
             curl_close($ch);

--- a/src/Provider/Picsum.php
+++ b/src/Provider/Picsum.php
@@ -23,7 +23,7 @@ class Picsum extends Image
         $format = 'jpg',
         $unused = false,
         $unused_ = false,
-        $unused3 = false
+        $unused3 = false,
     ) {
         $format = strtolower($format);
         $url    = sprintf(


### PR DESCRIPTION
There is an issue we’re facing in upgrading to PHP 8.1 with WP CLI Fixtures.

This occurs on PHP 8.1 (and now confirmed on PHP 8.0) when running `wp fixtures load`. The error we’re getting is:

```
Fatal error: Declaration of Hellonico\Fixtures\Provider\Picsum::imageUrl($width = 640, $height = 480, $filters = [],
 $format = 'jpg', $unused = false, $unused_ = false) must be compatible with Faker\Provider\Image::imageUrl($width = 640, 
$height = 480, $category = null, $randomize = true, $word = null, $gray = false, $format = 'png') 
in /var/www/.wp-cli/packages/vendor/hellonico/wp-cli-fixtures/src/Provider/Picsum.php on line 19
```

Taking a look at [Picsum.php](https://github.com/nlemoine/wp-cli-fixtures/blob/main/src/Provider/Picsum.php#L55), it has a different number of parameters to the parent method in [Image.php](https://github.com/FakerPHP/Faker/blob/main/src/Faker/Provider/Image.php#L46)

Changing `Picsum.php` to add the additional parameter gets it working again.

It seems the interface of the `Faker\Provider\Image::imageUrl()` function was changed in version 1.20.0 (https://github.com/FakerPHP/Faker/blob/main/src/Faker/Provider/Image.php) - and at the very bottom of the Faker PR someone comments that it's broken Backwards Compatiblity: (https://github.com/FakerPHP/Faker/pull/473).
We're finding that it's only PHP 8.x that is reporting this compatibility error (due to increased PHP 8 type checking - see the section on Contravariance in (https://php.watch/versions/8.0/lsp-errors)).

The Faker reference is in wp-cli-fixtures' `composer.json`: https://github.com/nlemoine/wp-cli-fixtures/blob/main/composer.json:

```
"require": {
  "php": "^7.3 || ^8.0",
  "fakerphp/faker": "^1.13",
  "nelmio/alice": "^3.8",
  "wp-cli/wp-cli": "^2.4"
 },
```

This PR updates the `Picsum::imageUrl()` method signature to match the parent from Faker, and also updates the dependency to the latest version 1.20.0.

Tested on:
- PHP 7.4
- PHP 8.0
- PHP 8.1