### PR TITLE
Fix for example fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Hellonico\Fixtures\Entity\Post:
       # repeater field
       features:
         - label: <words(2, true)>
-          value: <sentence()
+          value: <sentence()>
         - label: <words(2, true)>
           value: <sentence()>
         - label: <words(2, true)>

--- a/examples/fixtures.yml
+++ b/examples/fixtures.yml
@@ -112,7 +112,7 @@ Hellonico\Fixtures\Entity\Post:
       # repeater field
       features:
         - label: <words(2, true)>
-          value: <sentence()
+          value: <sentence()>
         - label: <words(2, true)>
           value: <sentence()>
         - label: <words(2, true)>


### PR DESCRIPTION
Add closing bracket for `<sentence()>`  in the `README.MD` and `examples/fixtures.yml` file