### PR TITLE
Add support for MetaBox relationships 

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,14 +344,53 @@ Hellonico\Fixtures\Entity\Post:
       # repeater field
       features:
         - label: <words(2, true)>
-          value: <sentence()
+          value: <sentence()>
         - label: <words(2, true)>
           value: <sentence()>
         - label: <words(2, true)>
           value: <sentence()>
 ```
-
 Be careful with duplicate field keys, if you have multiple field with the same key, prefer using ACF field key (`field_948d1qj5mn4d3`).
+
+### MetaBox Support
+
+#### MetaBox Custom Fields
+MetaBox fields can be adressed using the `meta` key
+```yaml
+Hellonico\Fixtures\Entity\Post:
+  post{1..30}:
+    post_title: <words(3, true)>
+    post_date: <dateTimeThisDecade()>
+    meta:
+      # number field
+      number: <numberBetween(10, 200)>
+      custom_field: <sentence()>
+```
+
+#### MetaBox Relationships (https://docs.metabox.io/extensions/mb-relationships/#using-code)
+When using the MB Relationships extension, the relationships can be set/defined using the key `mb_relations`. For each relationship you want to create a fixture for, you use the relationship-ID which is used to register the MB-relation 
+```php
+ MB_Relationships_API::register( [
+        'id'   => 'post_to_term',
+        'from'   => 'post',
+        'to' => [
+            'object_type' => 'term',
+            'taxonomy'=> 'custom_term'
+        ],
+        
+    ] );
+```
+and the post/term ID of the object you want it to have a relationship with.
+```yaml
+Hellonico\Fixtures\Entity\Post:
+  post{1..30}:
+    post_title: <words(3, true)>
+    post_date: <dateTimeThisDecade()>
+    mb_relations:
+      post_to_term: '1x @custom_term*->term_id'
+      post_to_post: '1x @custom_post*->ID'
+```
+
 
 ### Custom formatters
 

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ Hellonico\Fixtures\Entity\Post:
     meta:
       # number field
       number: <numberBetween(10, 200)>
-      custom_field: <sentence()>
+      meta_box_custom_field: <sentence()>
 ```
 
 #### MetaBox Relationships (https://docs.metabox.io/extensions/mb-relationships/#using-code)

--- a/examples/fixtures.yml
+++ b/examples/fixtures.yml
@@ -97,6 +97,8 @@ Hellonico\Fixtures\Entity\Post:
   # CUSTOM POST TYPE
   product{1..15}:
     post_type: product
+    mb_relations:
+      post_to_term: '1x @places*->term_id'
     acf:
       # number field
       price: <numberBetween(10, 200)>

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -30,6 +30,7 @@ class Post extends Entity {
 	public $post_category;
 	public $meta_input;
 	public $acf;
+    public $mb_relations;
 	private $extra = [ 'meta_input', 'acf' ];
 
 	/**
@@ -115,6 +116,7 @@ class Post extends Entity {
 			update_post_meta( $this->ID, $meta_key, $meta_value );
 		}
 
+<<<<<<< HEAD
 		// Save ACF fields
 		if ( class_exists( 'acf' ) && ! empty( $this->acf ) && is_array( $this->acf ) ) {
 			foreach ( $this->acf as $name => $value ) {
@@ -125,6 +127,18 @@ class Post extends Entity {
 				update_field( $field['key'], $value, $post_id );
 			}
 		}
+=======
+        if( defined( 'RWMB_VER' ) && class_exists( 'MB_Relationships_API' ) && !empty( $this->mb_relations ) && is_array( $this->mb_relations )){
+			foreach ( $this->mb_relations as $mb_rel_id => $object_ids ){
+				foreach ( $object_ids as $id ){
+					\MB_Relationships_API::add( $post_id, $id, $mb_rel_id );
+				}
+			}
+        }
+
+        return true;
+    }
+>>>>>>> 10d8c92 (feat(MetaBoxRelationships): add support to set MetaBox Relationships through fixtures.yml file)
 
 		return true;
 	}

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -30,7 +30,7 @@ class Post extends Entity {
 	public $post_category;
 	public $meta_input;
 	public $acf;
-    public $mb_relations;
+	public $mb_relations;
 	private $extra = [ 'meta_input', 'acf' ];
 
 	/**
@@ -116,7 +116,6 @@ class Post extends Entity {
 			update_post_meta( $this->ID, $meta_key, $meta_value );
 		}
 
-<<<<<<< HEAD
 		// Save ACF fields
 		if ( class_exists( 'acf' ) && ! empty( $this->acf ) && is_array( $this->acf ) ) {
 			foreach ( $this->acf as $name => $value ) {
@@ -127,18 +126,14 @@ class Post extends Entity {
 				update_field( $field['key'], $value, $post_id );
 			}
 		}
-=======
-        if( defined( 'RWMB_VER' ) && class_exists( 'MB_Relationships_API' ) && !empty( $this->mb_relations ) && is_array( $this->mb_relations )){
-			foreach ( $this->mb_relations as $mb_rel_id => $object_ids ){
-				foreach ( $object_ids as $id ){
+
+		if ( defined( 'RWMB_VER' ) && class_exists( 'MB_Relationships_API' ) && ! empty( $this->mb_relations ) && is_array( $this->mb_relations ) ) {
+			foreach ( $this->mb_relations as $mb_rel_id => $object_ids ) {
+				foreach ( $object_ids as $id ) {
 					\MB_Relationships_API::add( $post_id, $id, $mb_rel_id );
 				}
 			}
-        }
-
-        return true;
-    }
->>>>>>> 10d8c92 (feat(MetaBoxRelationships): add support to set MetaBox Relationships through fixtures.yml file)
+		}
 
 		return true;
 	}

--- a/src/Entity/Term.php
+++ b/src/Entity/Term.php
@@ -99,17 +99,14 @@ class Term extends Entity {
 			}
 		}
 
-        // Save MetaBox Relationships
-        if( defined( 'RWMB_VER' ) && class_exists( 'MB_Relationships_API' ) && !empty( $this->mb_relations ) && is_array( $this->mb_relations )){
-			foreach ( $this->mb_relations as $mb_rel_id => $object_ids ){
-				foreach ( $object_ids as $id ){
+		// Save MetaBox Relationships
+		if ( defined( 'RWMB_VER' ) && class_exists( 'MB_Relationships_API' ) && ! empty( $this->mb_relations ) && is_array( $this->mb_relations ) ) {
+			foreach ( $this->mb_relations as $mb_rel_id => $object_ids ) {
+				foreach ( $object_ids as $id ) {
 					\MB_Relationships_API::add( $post_id, $id, $mb_rel_id );
 				}
 			}
-        }
-
-        return true;
-    }
+		}
 
 		return true;
 	}

--- a/src/Entity/Term.php
+++ b/src/Entity/Term.php
@@ -14,6 +14,7 @@ class Term extends Entity {
 	public $description;
 	public $parent;
 	public $acf;
+	public $mb_relations;
 
 	/**
 	 * Constructor.

--- a/src/Entity/Term.php
+++ b/src/Entity/Term.php
@@ -98,6 +98,18 @@ class Term extends Entity {
 			}
 		}
 
+        // Save MetaBox Relationships
+        if( defined( 'RWMB_VER' ) && class_exists( 'MB_Relationships_API' ) && !empty( $this->mb_relations ) && is_array( $this->mb_relations )){
+			foreach ( $this->mb_relations as $mb_rel_id => $object_ids ){
+				foreach ( $object_ids as $id ){
+					\MB_Relationships_API::add( $post_id, $id, $mb_rel_id );
+				}
+			}
+        }
+
+        return true;
+    }
+
 		return true;
 	}
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -88,6 +88,18 @@ class User extends Entity {
 			}
 		}
 
+        // Save MetaBox Relationships
+        if( defined( 'RWMB_VER' ) && class_exists( 'MB_Relationships_API' ) && !empty( $this->mb_relations ) && is_array( $this->mb_relations )){
+			foreach ( $this->mb_relations as $mb_rel_id => $object_ids ){
+				foreach ( $object_ids as $id ){
+					\MB_Relationships_API::add( $post_id, $id, $mb_rel_id );
+				}
+			}
+        }
+
+        return true;
+    }
+
 		return true;
 	}
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -29,6 +29,7 @@ class User extends Entity {
 	public $use_ssl;
 	public $show_admin_bar_front;
 	public $acf;
+	public $mb_relations;
 
 	/**
 	 * {@inheritdoc}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -89,17 +89,14 @@ class User extends Entity {
 			}
 		}
 
-        // Save MetaBox Relationships
-        if( defined( 'RWMB_VER' ) && class_exists( 'MB_Relationships_API' ) && !empty( $this->mb_relations ) && is_array( $this->mb_relations )){
-			foreach ( $this->mb_relations as $mb_rel_id => $object_ids ){
-				foreach ( $object_ids as $id ){
+		// Save MetaBox Relationships
+		if ( defined( 'RWMB_VER' ) && class_exists( 'MB_Relationships_API' ) && ! empty( $this->mb_relations ) && is_array( $this->mb_relations ) ) {
+			foreach ( $this->mb_relations as $mb_rel_id => $object_ids ) {
+				foreach ( $object_ids as $id ) {
 					\MB_Relationships_API::add( $post_id, $id, $mb_rel_id );
 				}
 			}
-        }
-
-        return true;
-    }
+		}
 
 		return true;
 	}


### PR DESCRIPTION
Currently, the `wp-cli-fixtures` package does support `Advanced Custom Fields` but not `MetaBox`.

By default,  `MetaBox` custom-field fixtures can be set through the `meta` property in the `fixtures.yml` file, but when using the MetaBox integration/extension for defining relationships (https://docs.metabox.io/extensions/mb-relationships/), the integration is missing, which this PR tries to add.

Fixtures Relationships for Posts/Terms/Users would now be defined under the property `mb_relations`

```yaml
Hellonico\Fixtures\Entity\Post:
    # TEMPLATE
    default (template):
        post_title: <words(2, true)>
        post_date: <dateTimeThisDecade()>
        post_content: <paragraphs(5, true)>
        post_excerpt: <paragraphs(1, true)>

    # POSTS
    post{1..30} (extends default):
        post_title: <words(4, true)>

    custom_post{1..30} (extends default):
        post_type: 'custom_post'
        mb_relations:
            post_to_terms: '1x @custom_term*->term_id'
            post_to_post: '1x @post*->ID'
``` 

Updated the `README.md` and `examples/fixtures.yml` with documentation and example implementations 